### PR TITLE
Get dialog demo working

### DIFF
--- a/demo/Demo/Dialog.elm
+++ b/demo/Demo/Dialog.elm
@@ -76,14 +76,10 @@ element1 lift model =
 view : (Msg m -> m) -> Page m -> Model -> Html m
 view lift page model =
   page.body "Dialog"
-  [ Button.render (Mdl >> lift) [0] model.mdl
+  [ element lift model
+  , Button.render (Mdl >> lift) [0] model.mdl
     [ Dialog.openOn "click"
     ]
     [ text "Show dialog"
-    ]
-  , Button.render (Mdl >> lift) [1] model.mdl
-    [ Dialog.openOn "click"
-    ]
-    [ text "Show scrolling dialog"
     ]
   ]

--- a/src/Material/Dialog.elm
+++ b/src/Material/Dialog.elm
@@ -137,7 +137,7 @@ openOn =
       }
       catch (e)
       {
-        console.log ("A dialog method threw an exception. This is not supposed to happen; likely you're using a broken polyfill. If not, please file an issue:\\n\\nhttps://github.com/debois/elm-mdl/issues/new");
+        console.log ("A dialog method threw an exception. This is not supposed to happen; likely you're using a broken polyfill. If not, please file an issue:\\n\\nhttps://github.com/debois/elm-mdl/issues/new", e);
       }
       """
     in
@@ -176,7 +176,7 @@ closeOn =
       }
       catch (e)
       {
-        console.log ("A dialog method threw an exception. This is not supposed to happen; likely you're using a broken polyfill. If not, please file an issue:\\n\\nhttps://github.com/debois/elm-mdl/issues/new");
+        console.log ("A dialog method threw an exception. This is not supposed to happen; likely you're using a broken polyfill. If not, please file an issue:\\n\\nhttps://github.com/debois/elm-mdl/issues/new", e);
       }
       """
     in

--- a/src/Material/Dialog.elm
+++ b/src/Material/Dialog.elm
@@ -1,7 +1,6 @@
 module Material.Dialog
     exposing
         ( view
-        , open
         , header
         , title
         , body
@@ -26,7 +25,7 @@ module Material.Dialog
 Refer to [this site](http://debois.github.io/elm-mdl/#dialog)
 for a live demo.
 
-@docs view, open
+@docs view
 
 # Contents
 @docs title, body, header, footer, scrollable
@@ -205,10 +204,3 @@ view styling nodes =
         [ Html.div [ Html.class "mdc-dialog__surface" ] nodes
         , Html.div [ Html.class "mdc-dialog__backdrop" ] []
         ]
-
-
-{-| TODO - can this be removed? It's not in the MDC docs : https://github.com/material-components/material-components-web/tree/master/packages/mdc-dialog
--}
-open : Style a
-open =
-    cs "mdc-dialog--open"

--- a/src/Material/Dialog.elm
+++ b/src/Material/Dialog.elm
@@ -40,7 +40,7 @@ for a live demo.
 
 import Html exposing (..)
 import Html.Attributes as Html
-import Material.Options as Options exposing (Style, Property, cs)
+import Material.Options as Options exposing (Style, Property, cs, css)
 import Material.Internal.Options as Internal
 
 
@@ -134,6 +134,7 @@ openOn =
           }
         }
         dialog.showModal();
+        dialog.classList.add("mdc-dialog--open");
       }
       catch (e)
       {
@@ -173,6 +174,7 @@ closeOn =
           return;
         }
         dialog.close();
+        dialog.classList.remove("mdc-dialog--open");
       }
       catch (e)
       {
@@ -199,7 +201,7 @@ Installing more than one dialog will result in a random one showing.
 view : List (Style a) -> List (Html a) -> Html a
 view styling nodes =
     Options.styled_ (Html.node "dialog")
-        (cs "mdc-dialog" :: styling)
+        (css "display" "flex" :: cs "mdc-dialog" :: styling)
         [ Html.id theDialog ]
         [ Html.div [ Html.class "mdc-dialog__surface" ] nodes
         , Html.div [ Html.class "mdc-dialog__backdrop" ] []

--- a/src/Material/Dialog.elm
+++ b/src/Material/Dialog.elm
@@ -195,7 +195,7 @@ polyfill](https://github.com/GoogleChrome/dialog-polyfill).
 - Using this polyfill [places
 restrictions](https://github.com/GoogleChrome/dialog-polyfill#limitations) on
 where in the DOM you can put the output of this function.
-- The elm-mdl library currently support only one dialog pr. application.
+- The elm-mdc library currently support only one dialog per application.
 Installing more than one dialog will result in a random one showing.
 -}
 view : List (Style a) -> List (Html a) -> Html a


### PR DESCRIPTION
Follow on from #37 

This gets the dialog in the demo working, with the constraint that there can be only one dialog per application. Not a great constraint, but it's the same as elm-mdl.

What are your thoughts on utilising the JS foundations that are part of `material-components-web`? (e.g. https://github.com/material-components/material-components-web/blob/master/packages/mdc-dialog/foundation.js). Is this possible? Or is the idea to implement this behaviour in Elm? Sorry, my lack of Elm knowledge might be showing ;)