### PR TITLE
Change class of toolbarSpacer

### DIFF
--- a/src/Material/Drawer.elm
+++ b/src/Material/Drawer.elm
@@ -196,7 +196,7 @@ content options =
 toolbarSpacer : List (Property m) -> List (Html m) -> Html m
 toolbarSpacer options =
     styled Html.div
-    ( cs "mdc-persistent-drawer__toolbar-spacer"
+    ( cs "mdc-drawer__toolbar-spacer"
     :: options
     )
 


### PR DESCRIPTION
This patch changes the class of toolbarSpacerd's div from mdc-persistent-drawer__toolbar-spacer to mdc-drawer__toolbar-spacer.
The first one doesn't seem to work.