### PR TITLE
Make Temporary and Persistent Drawer programatic

### DIFF
--- a/demo/Demo/PersistentDrawer.elm
+++ b/demo/Demo/PersistentDrawer.elm
@@ -27,6 +27,7 @@ import Platform.Cmd exposing (Cmd, none)
 type alias Model m =
     { mdc : Material.Model m
     , rtl : Bool
+    , drawerOpen: Bool
     }
 
 
@@ -34,12 +35,14 @@ defaultModel : Model m
 defaultModel =
     { mdc = Material.defaultModel
     , rtl = False
+    , drawerOpen = False
     }
 
 
 type Msg m
     = Mdc (Material.Msg m)
     | ToggleRtl
+    | ToggleDrawer
 
 
 update : (Msg m -> m) -> Msg m -> Model m -> ( Model m, Cmd m )
@@ -50,6 +53,9 @@ update lift msg model =
 
         ToggleRtl ->
             ( { model | rtl = not model.rtl }, Cmd.none )
+
+        ToggleDrawer ->
+            ( {model | drawerOpen = not model.drawerOpen}, Cmd.none )
 
 
 drawerItems : Html m
@@ -133,7 +139,8 @@ view lift page model =
     , Options.attribute (Html.dir "rtl") |> when model.rtl
     ]
     [
-      Drawer.view (lift << Mdc) [0] model.mdc []
+      Drawer.view (lift << Mdc) [0] model.mdc
+      [ Drawer.open |> when model.drawerOpen]
       [
         Drawer.toolbarSpacer [] []
       , drawerItems
@@ -155,7 +162,7 @@ view lift page model =
             [ Toolbar.alignStart
             ]
             [ Icon.view
-              [ Drawer.toggleOn (lift << Mdc) [0] "click"
+              [ Options.onClick (lift ToggleDrawer)
               , Toolbar.menuIcon
               ]
               "menu"

--- a/demo/Demo/TemporaryDrawer.elm
+++ b/demo/Demo/TemporaryDrawer.elm
@@ -27,6 +27,7 @@ import Platform.Cmd exposing (Cmd, none)
 type alias Model m =
     { mdc : Material.Model m
     , rtl : Bool
+    , drawerOpen : Bool
     }
 
 
@@ -34,12 +35,15 @@ defaultModel : Model m
 defaultModel =
     { mdc = Material.defaultModel
     , rtl = False
+    , drawerOpen = False
     }
 
 
 type Msg m
     = Mdc (Material.Msg m)
     | ToggleRtl
+    | OpenDrawer
+    | CloseDrawer
 
 
 update : (Msg m -> m) -> Msg m -> Model m -> ( Model m, Cmd m )
@@ -51,6 +55,11 @@ update lift msg model =
         ToggleRtl ->
             ( { model | rtl = not model.rtl }, Cmd.none )
 
+        OpenDrawer ->
+            ( { model | drawerOpen = True}, Cmd.none )
+
+        CloseDrawer ->
+            ( { model | drawerOpen = False}, Cmd.none )
 
 view : (Msg m -> m) -> Page m -> Model m -> Html m
 view lift page model =
@@ -67,7 +76,7 @@ view lift page model =
           ]
           [ Icon.view
             [ Toolbar.menuIcon
-            , Drawer.openOn (lift << Mdc) [0] "click"
+            , Options.onClick (lift OpenDrawer)
             ]
             "menu"
           , Toolbar.title
@@ -80,7 +89,10 @@ view lift page model =
         ]
       ]
 
-    , Drawer.view (lift << Mdc) [0] model.mdc []
+    , Drawer.view (lift << Mdc) [0] model.mdc
+      [ Drawer.open |> when model.drawerOpen
+      , Drawer.onClose (lift CloseDrawer)
+      ]
       [ Drawer.header
         [ Theme.primaryBg
         , Theme.textPrimaryOnPrimary

--- a/src/Material/Drawer/Persistent.elm
+++ b/src/Material/Drawer/Persistent.elm
@@ -2,7 +2,7 @@ module Material.Drawer.Persistent exposing
     ( content
     , header
     , headerContent
-    , toggleOn
+    , open
     , Property
     , toolbarSpacer
     , view
@@ -69,7 +69,7 @@ Drawer.view Mdc [0] model.mdc []
 @docs toolbarSpacer
 @docs header
 @docs headerContent
-@docs toggleOn
+@docs open
 -}
 
 import Html exposing (Html)
@@ -77,7 +77,6 @@ import Material
 import Material.Component exposing (Index)
 import Material.Internal.Drawer.Persistent.Implementation as Drawer
 import Material.List as Lists
-import Material.Options as Options
 
 
 {-| Drawer property.
@@ -127,19 +126,8 @@ toolbarSpacer =
     Drawer.toolbarSpacer
 
 
-{-| Toggles the drawer on interaction.
-
-```elm
-import Html exposing (text)
-import Material.Button as Button
-
-Button.view Mdc [0] model.mdc
-    [ Drawer.toggleOn Mdc [1] "click"
-    ]
-    [ text "Toggle Drawer with ID [1]"
-    ]
-```
+{-| When present, makes the drawer open.
 -}
-toggleOn : (Material.Msg m -> m) -> Index -> String -> Options.Property c m
-toggleOn =
-    Drawer.toggleOn
+open : Property m
+open =
+    Drawer.open

--- a/src/Material/Drawer/Temporary.elm
+++ b/src/Material/Drawer/Temporary.elm
@@ -2,7 +2,8 @@ module Material.Drawer.Temporary exposing
     ( content
     , header
     , headerContent
-    , openOn
+    , onClose
+    , open
     , Property
     , toolbarSpacer
     , view
@@ -65,7 +66,8 @@ Drawer.view Mdc [0] model.mdc []
 @docs toolbarSpacer
 @docs header
 @docs headerContent
-@docs openOn
+@docs onClose
+@docs open
 -}
 
 import Html exposing (Html)
@@ -73,7 +75,6 @@ import Material
 import Material.Component exposing (Index)
 import Material.Internal.Drawer.Temporary.Implementation as Drawer
 import Material.List as Lists
-import Material.Options as Options
 
 
 {-| Drawer property.
@@ -123,19 +124,15 @@ toolbarSpacer =
     Drawer.toolbarSpacer
 
 
-{-| Opens the drawer on interaction.
-
-```elm
-import Html exposing (text)
-import Material.Button as Button
-
-Button.view Mdc [0] model.mdc
-    [ Drawer.openOn Mdc [1] "click"
-    ]
-    [ text "Open Drawer with ID [1]"
-    ]
-```
+{-| Message that must be sent when the drawer wants to be close
 -}
-openOn : (Material.Msg m -> m) -> Index -> String -> Options.Property c m
-openOn =
-    Drawer.openOn
+onClose : m -> Property m
+onClose =
+    Drawer.onClose
+
+
+{-| When present, makes the drawer open.
+-}
+open : Property m
+open =
+    Drawer.open

--- a/src/Material/Internal/Drawer/Model.elm
+++ b/src/Material/Internal/Drawer/Model.elm
@@ -27,11 +27,8 @@ defaultModel =
 type Msg
     = NoOp
     | Tick
-    | Click
 
-    | Open Bool
-    | Close
-    | Toggle Bool
+    | SetOpen (Bool, Bool)
 
 
 type alias Geometry =

--- a/src/Material/Internal/Drawer/Permanent/Implementation.elm
+++ b/src/Material/Internal/Drawer/Permanent/Implementation.elm
@@ -15,11 +15,11 @@ import Material.Internal.List.Implementation as Lists
 import Material.Internal.Msg
 
 
-type alias Config =
-    Drawer.Config
+type alias Config m =
+    Drawer.Config m
 
 
-defaultConfig : Config
+defaultConfig : Config m
 defaultConfig =
     Drawer.defaultConfig
 

--- a/src/Material/Internal/Drawer/Persistent/Implementation.elm
+++ b/src/Material/Internal/Drawer/Persistent/Implementation.elm
@@ -2,27 +2,25 @@ module Material.Internal.Drawer.Persistent.Implementation exposing
     ( content
     , header
     , headerContent
-    , toggleOn
+    , open
     , Property
     , toolbarSpacer
     , view
     )
 
 import Html exposing (Html, text)
-import Json.Decode as Json
 import Material.Internal.Component exposing (Indexed, Index)
 import Material.Internal.Drawer.Implementation as Drawer
 import Material.Internal.Drawer.Model exposing (Model, Msg)
 import Material.Internal.List.Implementation as Lists
 import Material.Internal.Msg
-import Material.Internal.Options as Options
 
 
-type alias Config =
-    Drawer.Config
+type alias Config m=
+    Drawer.Config m
 
 
-defaultConfig : Config
+defaultConfig : Config m
 defaultConfig =
     Drawer.defaultConfig
 
@@ -86,9 +84,9 @@ subscriptions =
     Drawer.subscriptions
 
 
-toggleOn : (Material.Internal.Msg.Msg m -> m) -> Index -> String -> Options.Property c m
-toggleOn lift index event =
-    Options.on event (Json.succeed (lift (Material.Internal.Msg.DrawerMsg index (Material.Internal.Drawer.Model.Toggle True))))
+open : Property m
+open =
+    Drawer.open
 
 
 className : String

--- a/src/Material/Internal/Drawer/Temporary/Implementation.elm
+++ b/src/Material/Internal/Drawer/Temporary/Implementation.elm
@@ -2,27 +2,26 @@ module Material.Internal.Drawer.Temporary.Implementation exposing
     ( content
     , header
     , headerContent
-    , openOn
+    , onClose
+    , open
     , Property
     , toolbarSpacer
     , view
     )
 
 import Html exposing (Html, text)
-import Json.Decode as Json
 import Material.Internal.Component exposing (Indexed, Index)
 import Material.Internal.Drawer.Implementation as Drawer
 import Material.Internal.Drawer.Model exposing (Model, Msg)
 import Material.Internal.List.Implementation as Lists
 import Material.Internal.Msg
-import Material.Internal.Options as Options
 
 
-type alias Config =
-    Drawer.Config
+type alias Config m =
+    Drawer.Config m
 
 
-defaultConfig : Config
+defaultConfig : Config m
 defaultConfig =
     Drawer.defaultConfig
 
@@ -86,10 +85,14 @@ subscriptions =
     Drawer.subscriptions
 
 
-openOn : (Material.Internal.Msg.Msg m -> m) -> Index -> String -> Options.Property c m
-openOn lift index event =
-    Options.on event <| Json.succeed << lift <|
-    Material.Internal.Msg.DrawerMsg index (Material.Internal.Drawer.Model.Open False)
+onClose : m -> Property m
+onClose =
+    Drawer.onClose
+
+
+open : Property m
+open =
+    Drawer.open
 
 
 className : String


### PR DESCRIPTION
It is implemented the same way as Dialog:
* Drawer.open must passed to properties of `Drawer.view`
* for temporary drawer, an `onClose` property must be provided to handle
  the closing of the drawer

There is no more subscriptions in Drawer's implementation in order to
reduce code complexity in state handling (the subscriptions does not
have access to the `onClose` message).Thus the `onClose` message is now
only sent when the user clicks on the backdrop of the drawer.

It is now possible to close the drawer programatically by adding or
removing the `Drawer.open` property on `the Drawer.view` options.
This can be useful to close the drawer when the user clicks on a
drawer's item.

Usage:
 * TemporaryDrawer
```elm
Drawer.view
  (lift << Mdc )
  [ index ]
  model.mdc
  [ Drawer.open |> when model.drawerOpen
  , Drawer.onClose (lift CloseDrawer)
  ] [<content>]
```
* PersistenDrawer
```elm
[ Drawer.view
    (lift << Mdc )
    [ index ] ++ [0]
    model.mdc
    [ Drawer.open |> when model.drawerOpen
    ]
,
  Button.view
    (lift << Mdc)
    [ index ] ++ [1]
    model.mdc
    [ Options.onClick (lift ToggleDrawer)]
    [ text "Toggle drawer" ]
]
```