### PR TITLE
Drawer demo didn't work for me as iframe didn't load

### DIFF
--- a/demo/Demo/Drawer.elm
+++ b/demo/Demo/Drawer.elm
@@ -54,7 +54,7 @@ example label url =
       [
       ]
       [ Html.a
-        [ Html.href ("/elm-mdc" ++ url)
+        [ Html.href ("." ++ url)
         , Html.target "_blank"
         ]
         [ text "View in separate window"
@@ -62,7 +62,7 @@ example label url =
       ]
     ,
       styled Html.iframe
-      [ Options.attribute (Html.src ("/elm-mdc" ++ url))
+      [ Options.attribute (Html.src ("." ++ url))
       , css "height" "600px"
       , css "width" "100vw"
       , css "max-width" "780px"


### PR DESCRIPTION
I've slightly modified how the iframe contents is loaded, so it doesn't depend on any particular url now.

Still can't make this work by simply opening the file, but served through an actual web server this now works.