### PR TITLE
Select was broken since the v0.35.1 upgrade

### DIFF
--- a/demo/Demo/Selects.elm
+++ b/demo/Demo/Selects.elm
@@ -189,9 +189,9 @@ select lift id model selectedIndex options _ =
                      , Html.selected
                          (case selectedIndex of
                               Nothing ->
-                              False
+                                  False
                               Just i ->
-                              index == i
+                                  index == i
                          )
                      ]
                      [ text label ]

--- a/demo/Demo/Selects.elm
+++ b/demo/Demo/Selects.elm
@@ -1,12 +1,12 @@
 module Demo.Selects exposing (Model, defaultModel, Msg(Mdc), update, view, subscriptions)
 
+import Array
 import Demo.Page as Page exposing (Page)
 import Dict exposing (Dict)
 import Html.Attributes as Html
 import Html.Events as Html
 import Html exposing (Html, text)
 import Material
-import Material.Menu as Menu
 import Material.Options as Options exposing (styled, cs, css, when)
 import Material.Select as Select
 import Material.Typography as Typography
@@ -26,7 +26,7 @@ defaultModel =
 
 
 type alias Select =
-    { value : Maybe ( Int, String )
+    { value : Maybe String
     , rtl : Bool
     , disabled : Bool
     }
@@ -42,7 +42,7 @@ defaultSelect =
 
 type Msg m
     = Mdc (Material.Msg m)
-    | Pick (List Int) ( Int, String )
+    | Pick (List Int) String
     | ToggleRtl (List Int)
     | ToggleDisabled (List Int)
 
@@ -64,6 +64,9 @@ update lift msg model =
                     Dict.insert index select model.selects
             in
             ( { model | selects = selects }, Cmd.none )
+
+        -- Pick index value ->
+        --     ( model, Cmd.none )
 
         ToggleRtl index ->
             let
@@ -110,11 +113,8 @@ heroSelect lift id model options _ =
       , "Fats, Oils, and Sweets"
       ]
       |> List.indexedMap (\index label ->
-             Menu.li
-             [ Menu.onSelect (lift (Pick id ( index, label )))
-             -- TODO:
-             -- , Menu.disabled |> when ((index == 0) || (index == 3))
-             ]
+             Html.option
+             [ Html.value (toString index) ]
              [ text label ]
          )
     )
@@ -135,20 +135,34 @@ select
     : (Msg m -> m)
     -> List Int
     -> Model m
+    -> Maybe Int
     -> List (Select.Property m)
     -> List (Html m)
     -> List (Html m)
-select lift id model options _ =
+select lift id model selectedIndex options _ =
     let
         state =
             Dict.get id model.selects
             |> Maybe.withDefault defaultSelect
 
-        index =
-            Maybe.map Tuple.first state.value
+        fruits = Array.fromList
+            [ "Fruit Roll Ups"
+            , "Candy (cotton)"
+            , "Vegetables"
+            , "Noodles"
+            ]
 
-        selectedText =
-            Maybe.map Tuple.second state.value
+        selectedValue =
+            case state.value of
+                Nothing ->
+                    case selectedIndex of
+                        Nothing ->
+                            Nothing
+                        Just i ->
+                            Array.get i fruits
+                Just v ->
+                    state.value
+
     in
     [
       styled Html.section
@@ -159,36 +173,37 @@ select lift id model options _ =
       ]
       [
         Select.view (lift << Mdc) id model.mdc
-        ( Select.label "Food Group"
-        :: when (index /= Nothing)
-              (Select.index (Maybe.withDefault -1 index))
-        :: when (selectedText /= Nothing)
-              (Select.selectedText (Maybe.withDefault "" selectedText))
-        :: when state.disabled Select.disabled
-        :: css "width" "140px"
-        :: options
-        )
-        ( [ "Fruit Roll Ups"
-          , "Candy (cotton)"
-          , "Vegetables"
-          , "Noodles"
-          ]
-          |> List.indexedMap (\index label ->
-                 Menu.li
-                 [ Menu.onSelect (lift (Pick id ( index, label )))
-                 -- TODO:
-                 -- , Menu.disabled |> when ((index == 0) || (index == 3))
-                 ]
-                 [ text label ]
-             )
-        )
+            ( [ Select.label "Food Group"
+              , Options.onChange (lift << Pick id)
+              , Select.preselected |> when (selectedIndex /= Nothing)
+              , Select.disabled |> when state.disabled
+              , css "width" "160px"
+              ]
+              ++ options
+            )
+            ( fruits
+              |> Array.toList
+              |> List.indexedMap (\index label ->
+                     Html.option
+                     [ Html.value label
+                     , Html.selected
+                         (case selectedIndex of
+                              Nothing ->
+                              False
+                              Just i ->
+                              index == i
+                         )
+                     ]
+                     [ text label ]
+                 )
+            )
       ]
     ,
       Html.p []
       [ text "Currently selected: "
       , Html.span []
-        [ if index /= Nothing then
-            text (Maybe.withDefault "" selectedText ++ " at index " ++ toString (Maybe.withDefault -1 index) ++ " with value " ++ toString (Maybe.withDefault "" selectedText))
+        [ if selectedValue /= Nothing then
+            text (Maybe.withDefault "" selectedValue)
           else
             text "(none)"
         ]
@@ -229,17 +244,10 @@ view lift page model =
               Dict.get [0] model.selects
               |> Maybe.withDefault defaultSelect
 
-          index =
-              Maybe.map Tuple.first state.value
-
-          selectedText =
-              Maybe.map Tuple.second state.value
       in
       Page.hero []
       [ heroSelect lift [0] model
         [ Select.label "Pick a food group"
-        , Select.index (Maybe.withDefault -1 index) |> when (index /= Nothing)
-        , Select.selectedText (Maybe.withDefault "" selectedText) |> when (selectedText /= Nothing)
         , Select.disabled |> when state.disabled
         ]
         []
@@ -253,7 +261,7 @@ view lift page model =
             [ text "Select"
             ]
           ]
-        , select lift [1] model [] []
+        , select lift [1] model (Just 2) [ ] []
         ]
       )
     ,
@@ -265,7 +273,7 @@ view lift page model =
             [ text "Select box"
             ]
           ]
-        , select lift [2] model [ Select.box ] []
+        , select lift [2] model Nothing [ Select.box ] []
         ]
       )
     ]

--- a/src/Internal/Select/Implementation.elm
+++ b/src/Internal/Select/Implementation.elm
@@ -1,81 +1,64 @@
 module Internal.Select.Implementation exposing
     ( box
     , disabled
-    , index
     , label
+    , preselected
     , Property
     , react
-    , selectedText
-    , subs
     , view
     )
 
-import DOM
 import Html.Attributes as Html
 import Html exposing (Html, text)
 import Json.Decode as Json exposing (Decoder)
-import Internal.Component as Component exposing (Indexed, Index)
-import Internal.GlobalEvents as GlobalEvents
-import Internal.Menu.Implementation as Menu
-import Internal.Menu.Model as Menu
-import Internal.Msg
-import Internal.Options as Options exposing (cs, css, styled, when)
-import Internal.Select.Model exposing (Model, defaultModel, Msg(..), Geometry, defaultGeometry)
-
-
-subscriptions : Model -> Sub (Msg m)
-subscriptions model =
-    Sub.map (MenuMsg Nothing) (Menu.subscriptions model.menu)
+import Material.Internal.Component as Component exposing (Indexed, Index)
+import Material.Internal.Msg
+import Material.Internal.Options as Options exposing (cs, css, styled, when)
+import Material.Internal.Ripple.Implementation as Ripple
+import Material.Internal.Select.Model exposing (Model, defaultModel, Msg(..), Geometry, defaultGeometry)
 
 
 update : (Msg msg -> msg) -> Msg msg -> Model -> ( Maybe Model, Cmd msg )
 update lift msg model =
     case msg of
-
-        MenuMsg index msg_ ->
+        Input value ->
             let
-                (menu, menuCmd) =
-                    Menu.update (lift << MenuMsg index) msg_ model.menu
+                dirty =
+                    value /= ""
             in
-            case menu of
-                Just menu ->
-                    ( Just
-                        { model
-                            | menu = menu
-                            , index =
-                                case msg_ of
-                                    Menu.Toggle ->
-                                        if not model.menu.open then
-                                            index
-                                        else
-                                            Nothing
-                                    _ ->
-                                        model.index
-                        }
-                    , menuCmd
-                    )
-                Nothing ->
-                    ( Nothing, menuCmd )
+            ( Just { model | value = Just value, isDirty = dirty }, Cmd.none )
 
-        Init geometry ->
-            ( Just { model | geometry = Just geometry }, Cmd.none )
+        Blur ->
+            ( Just { model | focused = False }, Cmd.none )
 
+        Focus geometry ->
+            ( Just { model | focused = True }, Cmd.none )
+
+        NoOp ->
+            ( Just model, Cmd.none )
+
+        RippleMsg msg_ ->
+            let
+                ( ripple, effects ) =
+                    Ripple.update msg_ model.ripple
+            in
+            ( Just { model | ripple = ripple }, Cmd.map (lift << RippleMsg) effects )
 
 
 type alias Config =
     { label : String
-    , index : Maybe Int
-    , selectedText : Maybe String
+    , box : Bool
     , disabled : Bool
+    , preselected : Bool
     }
 
 
 defaultConfig : Config
 defaultConfig =
     { label = ""
-    , index = Nothing
-    , selectedText = Nothing
+    , box = False
     , disabled = False
+    , preselected= False
     }
 
 
@@ -88,14 +71,9 @@ label =
     Options.option << (\value config -> { config | label = value })
 
 
-index : Int -> Property m
-index index =
-    Options.option (\config -> { config | index = Just index })
-
-
-selectedText : String -> Property m
-selectedText selectedText =
-    Options.option (\ config -> { config | selectedText = Just selectedText })
+preselected : Property m
+preselected =
+    Options.option (\config -> { config | preselected = True })
 
 
 disabled : Property m
@@ -112,117 +90,57 @@ select
     : (Msg m -> m)
     -> Model
     -> List (Property m)
-    -> List (Menu.Item m)
+    -> List (Html m)
     -> Html m
 select lift model options items =
     let
         ({ config } as summary) =
             Options.collect defaultConfig options
 
-        geometry =
-            Maybe.withDefault defaultGeometry model.geometry
+        isDirty = model.isDirty
 
-        itemOffsetTop =
-            model.index
-            |> Maybe.andThen (\index ->
-                List.drop (Maybe.withDefault 0 model.index) geometry.itemOffsetTops
-                |> List.head
-               )
-            |> Maybe.map Just
-            |> Maybe.withDefault (
-                List.drop (Maybe.withDefault 0 config.index) geometry.itemOffsetTops
-                |> List.head
-               )
-            |> Maybe.withDefault 0
+        focused =
+            model.focused && not config.disabled
 
-        left =
-            geometry.boundingClientRect.left
+        isOpen = False -- TODO
 
-        top =
-            geometry.boundingClientRect.top
+        myItems =
+            if config.preselected then
+                items
+            else
+                Html.option
+                    [ Html.value ""
+                    , Html.disabled True
+                    , Html.selected True ]
+                []
+                :: items
 
-        adjustedTop =
-            let
-                adjustedTop_ =
-                    top - itemOffsetTop
-
-                overflowsTop =
-                    adjustedTop_ < 0
-
-                overflowsBottom =
-                    adjustedTop_ + geometry.menuHeight > geometry.windowInnerHeight
-            in
-                if overflowsTop then
-                    0
-                else
-                    if overflowsBottom then
-                        max 0 (geometry.windowInnerHeight - geometry.menuHeight)
-                    else
-                        adjustedTop_
-
-        transformOrigin =
-            "center " ++ toString itemOffsetTop ++ "px"
-
-        isOpen =
-          if model.menu.animating then
-              model.menu.open && (model.menu.geometry /= Nothing)
-          else
-              model.menu.open
     in
     Options.apply summary Html.div
     [ cs "mdc-select"
-    , cs "mdc-select--open" |> when isOpen
-    , when (model.menu.animating && model.menu.geometry == Nothing) <|
-      GlobalEvents.onTickWith
-          { targetRect = True
-          , parentRect = False
-          }
-          (Json.map (lift << Init) decodeGeometry)
-    , Menu.connect (lift << MenuMsg config.index) |> when (not config.disabled)
     , cs "mdc-select--disabled" |> when config.disabled
     ]
     [ Html.attribute "role" "listbox"
     , Html.tabindex 0
     ]
-    [ styled Html.div
-      [ cs "mdc-select__surface"
-      ]
-      [
-        styled Html.div
-        [ cs "mdc-select__label"
-        , cs "mdc-select__label--float-above" |> when (model.menu.open || (config.selectedText /= Nothing))
+    [ styled Html.select
+          [ cs "mdc-select__native-control"
+          , Options.on "focus" (Json.succeed (lift (Focus defaultGeometry)))
+          , Options.onBlur (lift Blur)
+          , Options.onInput (lift << Input)
+          ]
+          myItems
+    , styled Html.label
+        [ cs "mdc-floating-label"
+        , cs "mdc-floating-label--float-above" |> when (focused || isDirty || config.preselected)
         ]
         [ text config.label
         ]
-      ,
-        styled Html.div
-        [ cs "mdc-select__selected-text"
-        , css "pointer-events" "none"
-        ]
-        [ text (Maybe.withDefault "" config.selectedText)
-        ]
-      ,
-        styled Html.div
-        [ cs "mdc-select__bottom-line"
-        , cs "mdc-select__bottom-line--active" |> when model.menu.open
+    , styled Html.div
+        [ cs "mdc-line-ripple"
+        , cs "mdc-line-ripple--active" |> when focused
         ]
         []
-      ]
-    ,
-      Menu.menu (lift << MenuMsg config.index) model.menu
-      [ cs "mdc-select__menu"
-      , Menu.index (Maybe.withDefault 0 config.index)
-      , when isOpen << Options.many <|
-        [ css "position" "fixed"
-        , css "transform-origin" transformOrigin
-        , css "left" (toString left ++ "px")
-        , css "top" (toString adjustedTop ++ "px")
-        , css "bottom" "unset"
-        , css "right" "unset"
-        ]
-      ]
-      ( Menu.ul [] items
-      )
     ]
 
 
@@ -249,49 +167,7 @@ view :
     -> Index
     -> Store s
     -> List (Property m)
-    -> List (Menu.Item m)
+    -> List (Html m)
     -> Html m
 view =
-    Component.render get select Internal.Msg.SelectMsg
-
-
-subs : (Internal.Msg.Msg m -> m) -> Store s -> Sub m
-subs =
-    Component.subs Internal.Msg.SelectMsg .select subscriptions
-
-
-decodeGeometry : Decoder Geometry
-decodeGeometry =
-    let
-        windowInnerHeight =
-            Json.at ["ownerDocument", "defaultView"] (Json.at ["innerHeight"] Json.float)
-
-        boundingClientRect =
-            Json.at ["targetRect"] <|
-            Json.map4 (\top left width height ->
-                 { top = top
-                 , left = left
-                 , width = width
-                 , height = height
-                 }
-               )
-            (Json.at ["top"] Json.float)
-            (Json.at ["left"] Json.float)
-            (Json.at ["width"] Json.float)
-            (Json.at ["height"] Json.float)
-
-        menuHeight =
-            DOM.childNode 1 DOM.offsetHeight
-
-        itemOffsetTops =
-            DOM.childNode 1 <|   -- .mdc-select__menu
-            DOM.childNode 0 <|   -- .mdc-menu__items
-            DOM.childNodes DOM.offsetTop
-    in
-    boundingClientRect
-    |> Json.andThen (\boundingClientRect ->
-    Json.map3 (Geometry boundingClientRect)
-        (DOM.target windowInnerHeight)
-        (DOM.target menuHeight)
-        (DOM.target itemOffsetTops)
-      )
+    Component.render get select Material.Internal.Msg.SelectMsg

--- a/src/Internal/Select/Implementation.elm
+++ b/src/Internal/Select/Implementation.elm
@@ -11,11 +11,11 @@ module Internal.Select.Implementation exposing
 import Html.Attributes as Html
 import Html exposing (Html, text)
 import Json.Decode as Json exposing (Decoder)
-import Material.Internal.Component as Component exposing (Indexed, Index)
-import Material.Internal.Msg
-import Material.Internal.Options as Options exposing (cs, css, styled, when)
-import Material.Internal.Ripple.Implementation as Ripple
-import Material.Internal.Select.Model exposing (Model, defaultModel, Msg(..), Geometry, defaultGeometry)
+import Internal.Component as Component exposing (Indexed, Index)
+import Internal.Msg
+import Internal.Options as Options exposing (cs, css, styled, when)
+import Internal.Ripple.Implementation as Ripple
+import Internal.Select.Model exposing (Model, defaultModel, Msg(..), Geometry, defaultGeometry)
 
 
 update : (Msg msg -> msg) -> Msg msg -> Model -> ( Maybe Model, Cmd msg )
@@ -167,4 +167,4 @@ view :
     -> List (Html m)
     -> Html m
 view =
-    Component.render get select Material.Internal.Msg.SelectMsg
+    Component.render get select Internal.Msg.SelectMsg

--- a/src/Internal/Select/Implementation.elm
+++ b/src/Internal/Select/Implementation.elm
@@ -34,9 +34,6 @@ update lift msg model =
         Focus geometry ->
             ( Just { model | focused = True }, Cmd.none )
 
-        NoOp ->
-            ( Just model, Cmd.none )
-
         RippleMsg msg_ ->
             let
                 ( ripple, effects ) =

--- a/src/Internal/Select/Model.elm
+++ b/src/Internal/Select/Model.elm
@@ -7,33 +7,39 @@ module Internal.Select.Model exposing
     )
 
 import DOM
-import Internal.Menu.Model as Menu
+import Material.Internal.Ripple.Model as Ripple
 
 
 type alias Model =
-    { menu : Menu.Model
-    , geometry : Maybe Geometry
-    , index : Maybe Int
+    { geometry : Maybe Geometry
+    , focused : Bool
+    , isDirty : Bool
+    , value : Maybe String
+    , ripple : Ripple.Model
     }
 
 
 defaultModel : Model
 defaultModel =
-    { menu = Menu.defaultModel
-    , geometry = Nothing
-    , index = Nothing
+    { geometry = Nothing
+    , focused = False
+    , isDirty = False
+    , value = Nothing
+    , ripple = Ripple.defaultModel
     }
 
 
 type Msg m
-    = MenuMsg (Maybe Int) (Menu.Msg m)
-    | Init Geometry
+    = Blur
+    | Focus Geometry
+    | Input String
+    | NoOp
+    | RippleMsg Ripple.Msg
 
 
 type alias Geometry =
     { boundingClientRect : DOM.Rectangle
     , windowInnerHeight : Float
-    , menuHeight : Float
     , itemOffsetTops : List Float
     }
 
@@ -42,6 +48,5 @@ defaultGeometry : Geometry
 defaultGeometry =
     { boundingClientRect = { top = 0, left = 0, width = 0, height = 0 }
     , windowInnerHeight = 0
-    , menuHeight = 0
     , itemOffsetTops = []
     }

--- a/src/Internal/Select/Model.elm
+++ b/src/Internal/Select/Model.elm
@@ -7,7 +7,7 @@ module Internal.Select.Model exposing
     )
 
 import DOM
-import Material.Internal.Ripple.Model as Ripple
+import Internal.Ripple.Model as Ripple
 
 
 type alias Model =

--- a/src/Internal/Select/Model.elm
+++ b/src/Internal/Select/Model.elm
@@ -33,7 +33,6 @@ type Msg m
     = Blur
     | Focus Geometry
     | Input String
-    | NoOp
     | RippleMsg Ripple.Msg
 
 

--- a/src/Material.elm
+++ b/src/Material.elm
@@ -368,7 +368,6 @@ subscriptions lift model =
     Sub.batch
         [ Drawer.subs lift model.mdc
         , Menu.subs lift model.mdc
-        , Select.subs lift model.mdc
         ]
 
 

--- a/src/Material/Select.elm
+++ b/src/Material/Select.elm
@@ -1,10 +1,9 @@
 module Material.Select exposing
     ( box
     , disabled
-    , index
     , label
+    , preselected
     , Property
-    , selectedText
     , view
     )
 
@@ -18,7 +17,7 @@ manually.
 
 # Resources
 
-- [Material Design guidelines: Text Fields](https://material.io/guidelines/components/text-fields.html)
+- [Material Design guidelines: Select Menus](https://material.io/develop/web/components/input-controls/select-menus/)
 - [Material Design guidelines: Menus](https://material.io/guidelines/components/menus.html)
 - [Demo](https://aforemny.github.io/elm-mdc/#select)
 
@@ -26,25 +25,25 @@ manually.
 # Example
 
 ```elm
-import Material.Menu as Menu
+import Html exposing (..)
 import Material.Options exposing (css)
 import Material.Select as Select
 
 
 Select.view (lift << Mdc) id model.mdc
     [ Select.label "Food Group"
+    , Select.preselected
+    , Options.onChange ProcessMyChange
     , css "width" "377px"
     ]
-    [ Menu.li
-          [ Menu.onSelect (Select "Fruit Roll Ups")
+    [ Html.option
+          [ Html.value "Fruit Roll Ups"
+          , Html.selected True
           ]
-          [ text "Fruit Roll Ups"
-          ]
-    , Menu.li
-          [ Menu.onSelect (Select "Candy (cotton)")
-          ]
-          [ text "Candy (cotton)"
-          ]
+          [ text "Fruit Roll Ups" ]
+    , Html.option
+          [ Html.value "Candy (cotton)" ]
+          [ text "Candy (cotton)" ]
     ]
 ```
 
@@ -54,17 +53,15 @@ Select.view (lift << Mdc) id model.mdc
 @docs Property
 @docs view
 @docs label
-@docs selectedText
-@docs index
+@docs preselected
 @docs disabled
 @docs box
 -}
 
 import Html exposing (Html)
 import Material
-import Internal.Component exposing (Index)
-import Internal.Select.Implementation as Select
-import Material.Menu as Menu
+import Material.Component exposing (Index)
+import Material.Internal.Select.Implementation as Select
 
 
 {-| Select property.
@@ -80,7 +77,7 @@ view :
     -> Index
     -> Material.Model m
     -> List (Property m)
-    -> List (Menu.Item m)
+    -> List (Html m)
     -> Html m
 view =
     Select.view
@@ -100,18 +97,11 @@ label =
     Select.label
 
 
-{-| Set the index of the selected item.
+{-| Use this if an option has been preselected.
 -}
-index : Int -> Property m
-index =
-    Select.index
-
-
-{-| Set the textual representation of the selected item.
--}
-selectedText : String -> Property m
-selectedText =
-    Select.selectedText
+preselected : Property m
+preselected =
+    Select.preselected
 
 
 {-| Disable the select.

--- a/src/Material/Select.elm
+++ b/src/Material/Select.elm
@@ -60,8 +60,8 @@ Select.view (lift << Mdc) id model.mdc
 
 import Html exposing (Html)
 import Material
-import Material.Component exposing (Index)
-import Material.Internal.Select.Implementation as Select
+import Internal.Component exposing (Index)
+import Internal.Select.Implementation as Select
 
 
 {-| Select property.


### PR DESCRIPTION
Big change, so behind the scenes and how it works looks pretty different. Now works/operates like the standard Html.select/Html.option.

One thing I wonder about is the NoOp. Copied that from Textfield, but is that really needed? On second thoughts, answering my own question, no, so push change to remove that from this branch.