### PR TITLE
Emit icons with aria-hidden="true"

### DIFF
--- a/src/Internal/Icon/Implementation.elm
+++ b/src/Internal/Icon/Implementation.elm
@@ -37,7 +37,7 @@ view options name =
     in
     Options.apply summary
         (Html.node config.node)
-        (cs "material-icons" :: options)
+        (cs "material-icons" :: (Options.aria "hidden" "true") :: options)
         []
         [ text name ]
 

--- a/src/Material/Icon.elm
+++ b/src/Material/Icon.elm
@@ -23,6 +23,11 @@ This implementation assumes that you have
 or an equivalent means of loading the icons in your HTML header.
 
 
+The icon will have the aria-hidden attribute set to true to ensure
+that screen readers produce the correct output when reading this
+element.
+
+
 # Example
 
 ```elm


### PR DESCRIPTION
This is [per the docs](https://material.io/develop/web/components/buttons/icon-toggle-buttons/):

> Also note the aria-hidden attribute on the icon. This is important to ensure that screen readers produce the correct output when reading this element.