### PR TITLE
Allow floating values for steps as per the component

### DIFF
--- a/demo/Demo/Slider.elm
+++ b/demo/Demo/Slider.elm
@@ -18,7 +18,7 @@ type alias Model m =
     , inputs : Dict Material.Index Float
     , min : Int
     , max : Int
-    , steps : Int
+    , steps : Float
     , darkTheme : Bool
     , disabled : Bool
     , customBg : Bool
@@ -40,7 +40,7 @@ defaultModel =
         Dict.empty
     , min = 0
     , max = 50
-    , steps = 1
+    , steps = 0.25
     , darkTheme = False
     , disabled = False
     , customBg = False
@@ -54,7 +54,7 @@ type Msg m
     | Input Material.Index Float
     | SetMin Int
     | SetMax Int
-    | SetSteps Int
+    | SetSteps Float
     | ToggleDarkTheme
     | ToggleDisabled
     | ToggleCustomBg
@@ -310,13 +310,13 @@ view lift page model =
 
       , Html.div []
         [ Html.label []
-          [ text "Step: "
+          [ text "Step (change has no effect): "
           , Html.input
             [ Html.type_ "number"
             , Html.min "0"
             , Html.max "100"
-            , Html.defaultValue "1"
-            , Html.on "input" (Json.map (String.toInt >> Result.toMaybe >> Maybe.withDefault 1 >> SetSteps >> lift) (Html.targetValue))
+            , Html.defaultValue (toString model.steps)
+            , Html.on "input" (Json.map (String.toFloat >> Result.toMaybe >> Maybe.withDefault 1 >> SetSteps >> lift) (Html.targetValue))
             ]
             []
           ]

--- a/src/Internal/Slider/Implementation.elm
+++ b/src/Internal/Slider/Implementation.elm
@@ -218,7 +218,7 @@ valueForKey key keyCode geometry value =
                   identity
             ) <|
             ( if discrete then
-                  Maybe.withDefault 1 (Maybe.map toFloat steps)
+                  Maybe.withDefault 1 steps
               else
                   (max - min) / 100
             )
@@ -272,7 +272,7 @@ type alias Config m =
     , min : Float
     , max : Float
     , discrete : Bool
-    , steps : Int
+    , steps : Float
     , onInput : Maybe (Float -> m)
     , onChange : Maybe (Float -> m)
     , trackMarkers : Bool
@@ -630,7 +630,7 @@ slider lift model options _ =
                   styled Html.div
                   [ cs "mdc-slider__track-marker-container"
                   ]
-                  ( List.repeat ((round (config.max  - config.min)) // config.steps) <|
+                  ( List.repeat (round ((config.max - config.min) / config.steps)) <|
                     styled Html.div
                     [ cs "mdc-slider__track-marker"
                     ]
@@ -742,7 +742,6 @@ discretize geometry continuousValue =
 
         steps =
             geometry.steps
-            |> Maybe.map toFloat
             |> Maybe.withDefault 1
             |> \ steps ->
                if steps == 0 then
@@ -803,7 +802,7 @@ decodeGeometry =
         ( data "min" (Json.map (String.toFloat >> Result.withDefault 1) Json.string) )
         ( data "max" (Json.map (String.toFloat >> Result.withDefault 1) Json.string) )
         ( Json.oneOf
-          [ data "steps" (Json.map (Result.toMaybe << String.toInt) Json.string)
+          [ data "steps" (Json.map (Result.toMaybe << String.toFloat) Json.string)
           , Json.succeed Nothing
           ]
         )
@@ -837,11 +836,7 @@ onInput =
     Options.option << (\ decoder config -> { config | onInput = Just decoder } )
 
 
-{-| Specify a number of steps that value will be a multiple of.
-
-Defaults to 1.
--}
-steps : Int -> Property m
+steps : Float -> Property m
 steps =
     Options.option << (\ steps config -> { config | steps = steps } )
 

--- a/src/Internal/Slider/Implementation.elm
+++ b/src/Internal/Slider/Implementation.elm
@@ -7,7 +7,7 @@ module Internal.Slider.Implementation exposing
     , onInput
     , Property
     , react
-    , steps
+    , step
     , trackMarkers
     , value
     , view
@@ -55,7 +55,7 @@ Slider.view Mdc [0] model.mdc
 ## Discrete Slider
 
 @docs discrete
-@docs steps
+@docs step
 @docs trackMarkers
 
 
@@ -72,7 +72,7 @@ import Json.Decode as Json exposing (Decoder)
 import Internal.Component as Component exposing (Index, Indexed)
 import Internal.GlobalEvents as GlobalEvents
 import Internal.Msg
-import Internal.Options as Options exposing (styled, cs, css, when)
+import Internal.Options as Options exposing (styled, cs, css, when, aria)
 import Internal.Slider.Model exposing (Model, defaultModel, Msg(..), Geometry, defaultGeometry)
 import Svg
 import Svg.Attributes as Svg
@@ -208,7 +208,7 @@ valueForKey key keyCode geometry value =
         isRtl =
             False -- TODO
 
-        { max, min, steps, discrete } =
+        { max, min, step, discrete } =
             geometry
 
         delta =
@@ -218,7 +218,7 @@ valueForKey key keyCode geometry value =
                   identity
             ) <|
             ( if discrete then
-                  Maybe.withDefault 1 steps
+                  Maybe.withDefault 1 step
               else
                   (max - min) / 100
             )
@@ -272,7 +272,7 @@ type alias Config m =
     , min : Float
     , max : Float
     , discrete : Bool
-    , steps : Float
+    , step : Float
     , onInput : Maybe (Float -> m)
     , onChange : Maybe (Float -> m)
     , trackMarkers : Bool
@@ -284,7 +284,7 @@ defaultConfig =
     { value = 0
     , min = 0
     , max = 100
-    , steps = 1
+    , step = 1
     , discrete = False
     , onInput = Nothing
     , onChange = Nothing
@@ -434,8 +434,12 @@ slider lift model options _ =
 
         , Options.data "min" (toString config.min)
         , Options.data "max" (toString config.max)
-        , Options.data "steps" (toString config.steps)
-          |> when config.discrete
+        , Options.data "step" (toString config.step)
+
+        , Options.attribute (Html.attribute "role" "slider")
+        , aria "valuemin" (toString config.min)
+        , aria "valuemax" (toString config.min)
+        , aria "valuenow" (toString value)
 
         , when (model.geometry == Nothing) <|
           GlobalEvents.onTick <| Json.map (lift << Init) decodeGeometry
@@ -630,7 +634,7 @@ slider lift model options _ =
                   styled Html.div
                   [ cs "mdc-slider__track-marker-container"
                   ]
-                  ( List.repeat (round ((config.max - config.min) / config.steps)) <|
+                  ( List.repeat (round ((config.max - config.min) / config.step)) <|
                     styled Html.div
                     [ cs "mdc-slider__track-marker"
                     ]
@@ -737,11 +741,16 @@ view =
 discretize : Geometry -> Float -> Float
 discretize geometry continuousValue =
     let
-        { discrete, min, max } =
+        { step, min, max } =
             geometry
 
+        continuous =
+            case step of
+                Nothing -> True
+                Just v -> False
+
         steps =
-            geometry.steps
+            geometry.step
             |> Maybe.withDefault 1
             |> \ steps ->
                if steps == 0 then
@@ -750,7 +759,7 @@ discretize geometry continuousValue =
                    steps
     in
     clamp min max <|
-    if not discrete then
+    if continuous then
         continuousValue
     else
         let
@@ -788,12 +797,12 @@ decodeGeometry =
     DOM.target <|
     traverseToContainer <|
     Json.map6
-        ( \offsetWidth offsetLeft discrete min max steps ->
+        ( \offsetWidth offsetLeft discrete min max step ->
             { rect = { width = offsetWidth, left = offsetLeft }
             , discrete = discrete
             , min = min
             , max = max
-            , steps = steps
+            , step = step
             }
         )
         DOM.offsetWidth
@@ -802,7 +811,7 @@ decodeGeometry =
         ( data "min" (Json.map (String.toFloat >> Result.withDefault 1) Json.string) )
         ( data "max" (Json.map (String.toFloat >> Result.withDefault 1) Json.string) )
         ( Json.oneOf
-          [ data "steps" (Json.map (Result.toMaybe << String.toFloat) Json.string)
+          [ data "step" (Json.map (Result.toMaybe << String.toFloat) Json.string)
           , Json.succeed Nothing
           ]
         )
@@ -836,9 +845,9 @@ onInput =
     Options.option << (\ decoder config -> { config | onInput = Just decoder } )
 
 
-steps : Float -> Property m
-steps =
-    Options.option << (\ steps config -> { config | steps = steps } )
+step : Float -> Property m
+step =
+    Options.option << (\ step config -> { config | step = step } )
 
 
 {-| Add track markers to the Slider every `step`.

--- a/src/Internal/Slider/Model.elm
+++ b/src/Internal/Slider/Model.elm
@@ -45,7 +45,7 @@ type Msg m
 type alias Geometry =
     { rect : Rect
     , discrete : Bool
-    , steps : Maybe Int
+    , steps : Maybe Float
     , min : Float
     , max : Float
     }

--- a/src/Internal/Slider/Model.elm
+++ b/src/Internal/Slider/Model.elm
@@ -45,7 +45,7 @@ type Msg m
 type alias Geometry =
     { rect : Rect
     , discrete : Bool
-    , steps : Maybe Float
+    , step : Maybe Float
     , min : Float
     , max : Float
     }
@@ -63,5 +63,5 @@ defaultGeometry =
     , discrete = False
     , min = 0
     , max = 100
-    , steps = Nothing
+    , step = Nothing
     }

--- a/src/Material/Slider.elm
+++ b/src/Material/Slider.elm
@@ -134,11 +134,17 @@ onInput =
     Slider.onInput
 
 
-{-| Specify a number of steps that value will be a multiple of.
+{-| Specify the steps the value will be a multiple of.
+
+For example by specyfing 2 the allowed values will only be 0, 2, 4, 6,
+etc. if your initial value is 0. By specifying 0.25 the sequence is 0,
+0.25, 0.5, 0.75, 1, 1.25, etc.
 
 Defaults to 1.
+
+This value cannot be changed dynamically.
 -}
-steps : Int -> Property m
+steps : Float -> Property m
 steps =
     Slider.steps
 

--- a/src/Material/Slider.elm
+++ b/src/Material/Slider.elm
@@ -6,6 +6,7 @@ module Material.Slider exposing
     , onChange
     , onInput
     , Property
+    , step
     , steps
     , trackMarkers
     , value
@@ -50,6 +51,7 @@ Slider.view Mdc [0] model.mdc
 @docs value, min, max
 @docs disabled
 @docs onChange, onInput
+@docs step
 
 ## Discrete Slider
 
@@ -144,12 +146,19 @@ Defaults to 1.
 
 This value cannot be changed dynamically.
 -}
+step : Float -> Property m
+step =
+    Slider.step
+
+
+{-| Obsolete alias for step.
+-}
 steps : Float -> Property m
 steps =
-    Slider.steps
+    step
 
 
-{-| Add track markers to the Slider every `step`.
+{-| Discrete sliders support display markers on their tracks. A marker is displayed every `step`.
 -}
 trackMarkers : Property m
 trackMarkers =


### PR DESCRIPTION
Steps can be a float now, works for the "discrete" slider as per #93. Have not made the change to make this work for the non-discrete slider, running out of time for that one as I don't need that.