### PR TITLE
nix-shell: pin elm to nixpkgs-unstable

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,20 +1,14 @@
 { pkgs ? import <nixpkgs> {} }:
 let
-  pkgs_src = pkgs.fetchgit {
-    url = "https://github.com/domenkozar/nixpkgs";
-    rev = "6046600dfabf5b97ba077b9f345c6917c9ef80ad";
-    sha256 = "1rwc9iic6xwm9qbkr84njwcziy6dr3vg64nklpnq4fkfadb69gw4";
-    fetchSubmodules = true;
-  };
-
-  pkgs_ = import "${pkgs_src}" {};
+  nixpkgs-unstable = (import (fetchTarball "https://github.com/NixOS/nixpkgs-channels/archive/nixpkgs-unstable.tar.gz")) {};
 in
 with pkgs;
 with stdenv;
 mkDerivation {
   name = "elm-mdc";
   buildInputs = [
-    pkgs_.elmPackages.elm
+    # Elm 0.19 is available in the nixpkgs-unstable channel for now
+    nixpkgs-unstable.elmPackages.elm
     nodejs-9_x
   ];
 }


### PR DESCRIPTION
this should also ensure a better and reduce the rebuild of a lot of
packages locally