### PR TITLE
Fixes #117 Init scale to that of current tab, not first tab.

### DIFF
--- a/src/Internal/Tabs/Implementation.elm
+++ b/src/Internal/Tabs/Implementation.elm
@@ -331,7 +331,7 @@ update lift msg model =
               Just
                 { model
                     | geometry = Just geometry
-                    , scale = computeScale geometry 0
+                    , scale = computeScale geometry model.index
                     , forwardIndicator = forwardIndicator
                     , backIndicator = backIndicator
                     , translateOffset = translateOffset


### PR DESCRIPTION
This change allows for the possibility that a global resize could occur after selection of a particular tab. It ensures that the geometry of the currently-selected tab is calculated, whereas it previously always calculated the geometry of the first tab.