### PR TITLE
Replace ripple style node with inline style attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Bug fixes since 1.1.1 release
 
+Implementation changes:
+
+* Ripple code has been improved to emit CSS variables as inline
+  styles. There's a bug in Elm that makes this hard, but our
+  workaround does not seem to have drawbacks.
+  There's a pull request to fix this bug: https://github.com/elm/virtual-dom/pull/127
+  You no longer have to use the returned style property, although this
+  has been left in the interface so you can update existing code at your leasure.
+
+
 Stuff missed before I did the 1.1.1 release.
 
 * Do not specify TextField.outlined for multiline text fields.
@@ -8,20 +18,20 @@ Stuff missed before I did the 1.1.1 release.
 
 ## Upgrade to 0.44.1
 
-* Textfield
+* Textfield:
   * Material.TextField.HelperText now needs to be wrapped in Material.TextField.HelperLine.
   * Support for character counter via Material.TextField.CharacterCounter.
 
 
 ## Upgrade to 0.42
 
-* Textfield
+* Textfield:
   * Box option is now the default, option removed.
   * Remove dense option already, will be removed soon.
   * unClickable option is removed. Set onLeadingIconClick and
     onTrailingIconClick to indicate actions for any icons.
 
-* Dialog
+* Dialog:
   * Surface div is gone. Put header, content and actions directly as children from dialog.
   * Dialog.body is now Dialog.content
   * Dialog.footer is now Dialog.actions.

--- a/src/Internal/Button/Implementation.elm
+++ b/src/Internal/Button/Implementation.elm
@@ -159,8 +159,6 @@ button domId lift model options nodes =
                     (\icon_ -> [ Icon.view [ cs "mdc-button__icon" ] icon_ ])
                 |> Maybe.withDefault []
             , nodes
-            , [ rippleInterface.style
-              ]
             ]
         )
 

--- a/src/Internal/Button/Implementation.elm
+++ b/src/Internal/Button/Implementation.elm
@@ -136,7 +136,6 @@ button domId lift model options nodes =
         [ cs "mdc-button"
         , cs "mdc-js-button"
         , cs "mdc-js-ripple-effect" |> when summary.config.ripple
-        , css "box-sizing" "border-box"
         , Options.attribute (Html.href (Maybe.withDefault "" config.link))
             |> when ((config.link /= Nothing) && not config.disabled)
         , Options.attribute (Html.disabled True)

--- a/src/Internal/Chip/Implementation.elm
+++ b/src/Internal/Chip/Implementation.elm
@@ -216,8 +216,6 @@ chip domId lift model options nodes =
                         ]
                     )
                 |> Maybe.withDefault []
-            , [ ripple.style
-              ]
             ]
         )
 

--- a/src/Internal/Fab/Implementation.elm
+++ b/src/Internal/Fab/Implementation.elm
@@ -87,11 +87,6 @@ fab domId lift model options icon =
                     [ text icon
                     ]
               ]
-            , if config.ripple then
-                [ rippleInterface.style ]
-
-              else
-                []
             ]
         )
 

--- a/src/Internal/IconButton/Implementation.elm
+++ b/src/Internal/IconButton/Implementation.elm
@@ -122,7 +122,6 @@ iconButton domId lift model options list =
                   [ iconElement
                   , cs "material-icons" ]
                   [ text config.icon.off ]
-            , ripple.style
             ]
     in
     Options.apply summary
@@ -156,12 +155,10 @@ iconButton domId lift model options list =
                     cs config.icon.off
                 ]
                 []
-            , ripple.style
             ]
           else
               if config.icon.on == config.icon.off then
                   [ text config.icon.on
-                  , ripple.style
                   ]
               else
                   icons

--- a/src/Internal/Options.elm
+++ b/src/Internal/Options.elm
@@ -158,14 +158,28 @@ addAttributes : Summary c m -> List (Attribute m) -> List (Attribute m)
 addAttributes summary attrs =
     {- Ordering here is important: First apply summary attributes. That way,
        internal classes and attributes override those provided by the user.
-    -}
-    summary.attrs
-        ++ List.map (\( key, value ) -> Html.Attributes.style key value) summary.css
-        ++ List.map Html.Attributes.class summary.classes
-        ++ attrs
-        ++ summary.internal
-        ++ Dispatch.toAttributes summary.dispatch
 
+       We use Html.Attributes.attribute "style" to inject CSS
+       variables. Elm has easily fixed bug where these get removed if
+       you use Html.Attributes.style. Hopefully Evan will fix this one
+       day: https://github.com/elm/virtual-dom/pull/127/files
+    -}
+    let
+        styleText = String.join "; " ( List.map (\( key, value ) -> String.join ": " [ key, value ] ) summary.css )
+        style =
+            if styleText /= "" then
+                [ Html.Attributes.attribute "style" styleText ]
+            else
+                []
+        all =
+            summary.attrs
+            ++ style
+            ++ List.map Html.Attributes.class summary.classes
+            ++ attrs
+            ++ summary.internal
+            ++ Dispatch.toAttributes summary.dispatch
+    in
+        all
 
 option : (c -> c) -> Property c m
 option =

--- a/src/Internal/RadioButton/Implementation.elm
+++ b/src/Internal/RadioButton/Implementation.elm
@@ -119,7 +119,6 @@ radioButton domId lift model options _ =
             [ styled Html.div [ cs "mdc-radio__inner-circle" ] []
             , styled Html.div [ cs "mdc-radio__outer-circle" ] []
             ]
-        , ripple.style
         ]
 
 

--- a/src/Internal/Ripple/Model.elm
+++ b/src/Internal/Ripple/Model.elm
@@ -129,7 +129,7 @@ type alias ActivatedData =
     , wasElementMadeActive : Bool
     , activationEvent : Maybe Event
     , fgScale : Float
-    , initialSize : Float
+    , initialSize : Int
     , translateStart : String
     , translateEnd : String
     , activationHasEnded : Bool

--- a/src/Internal/TabBar/Implementation.elm
+++ b/src/Internal/TabBar/Implementation.elm
@@ -541,7 +541,6 @@ tabView domId lift model options index tab_ =
             , ripple.properties
             ]
             []
-        , ripple.style
         ]
 
 

--- a/src/Material/Ripple.elm
+++ b/src/Material/Ripple.elm
@@ -16,9 +16,6 @@ The view functions `unbounded` and `bounded` return a record with fields
     interacted with,
   - `properties` that applies the ripple effect to the HTML element. This is
     usually the same as the one `interactionHandler` is applied to, and
-  - `style` which is a HTML `<style>` element which has to be added to the DOM.
-    It is recommended to make this a child of the element that is interacted
-    with.
 
 
 # Resources
@@ -49,7 +46,6 @@ The view functions `unbounded` and `bounded` return a record with fields
         , properties
         ]
         [ text "Interact with me!"
-        , style
         ]
 
 
@@ -88,6 +84,8 @@ type alias Property m =
 
 
 {-| Bounded view function.
+
+The style property is obsolete, you do not need to use it anymore.
 -}
 bounded :
     (Material.Msg m -> m)
@@ -104,6 +102,8 @@ bounded =
 
 
 {-| Unbounded view function.
+
+The style property is obsolete, you do not need to use it anymore.
 -}
 unbounded :
     (Material.Msg m -> m)


### PR DESCRIPTION
Done by rewriting Options.addAttributes to emit style as an attribute, so CSS variables are not removed by Elm. We no longer need the style node.