### PR TITLE
Use CSS variable to retrieve horizontal scrollbar height

### DIFF
--- a/demo/Demo.elm
+++ b/demo/Demo.elm
@@ -77,8 +77,8 @@ type alias Model =
     }
 
 
-defaultModel : Browser.Navigation.Key -> Int -> Model
-defaultModel key horizontalScrollbarHeight =
+defaultModel : Browser.Navigation.Key -> Model
+defaultModel key =
     { mdc = Material.defaultModel
     , key = key
     , url = Demo.Url.StartPage
@@ -103,7 +103,7 @@ defaultModel key horizontalScrollbarHeight =
     , slider = Demo.Slider.defaultModel
     , snackbar = Demo.Snackbar.defaultModel
     , switch = Demo.Switch.defaultModel
-    , tabbar = Demo.TabBar.defaultModel horizontalScrollbarHeight
+    , tabbar = Demo.TabBar.defaultModel
     , modalDrawer = Demo.ModalDrawer.defaultModel
     , textfields = Demo.TextFields.defaultModel
     , theme = Demo.Theme.defaultModel
@@ -524,7 +524,7 @@ urlOf model =
     Demo.Url.toString model.url
 
 
-main : Program Flags Model Msg
+main : Program () Model Msg
 main =
     Browser.application
         { init = init
@@ -541,11 +541,11 @@ type alias Flags =
     }
 
 
-init : Flags -> Url.Url -> Browser.Navigation.Key -> ( Model, Cmd Msg )
+init : () -> Url.Url -> Browser.Navigation.Key -> ( Model, Cmd Msg )
 init flags url key =
     let
         initialModel =
-            defaultModel key flags.horizontalScrollbarHeight
+            defaultModel key
     in
     ( { initialModel | url = Demo.Url.fromUrl url }
     , Material.init Mdc

--- a/demo/Demo/TabBar.elm
+++ b/demo/Demo/TabBar.elm
@@ -16,15 +16,13 @@ import Platform.Cmd exposing (Cmd, none)
 type alias Model m =
     { mdc : Material.Model m
     , states : Dict Material.Index Int
-    , horizontalScrollbarHeight : Int
     }
 
 
-defaultModel : Int -> Model m
-defaultModel horizontalScrollbarHeight =
+defaultModel : Model m
+defaultModel =
     { mdc = Material.defaultModel
     , states = Dict.empty
-    , horizontalScrollbarHeight = horizontalScrollbarHeight
     }
 
 
@@ -119,7 +117,6 @@ scrollingTabs lift model index =
         index
         model.mdc
         [ TabBar.activeTab active_tab_index
-        , TabBar.horizontalScrollbarHeight model.horizontalScrollbarHeight
         ]
         ([ "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten", "Eleven", "Twelve" ]
             |> List.indexedMap (\i v -> tab lift model index i ("Tab " ++ v))

--- a/demo/page.html
+++ b/demo/page.html
@@ -18,7 +18,7 @@
     <script src="demo.js"></script>
     <div id="elm"></div>
     <script>
-      Elm.Main.init({ node: document.getElementById('elm'), flags: { horizontalScrollbarHeight: ElmMdc.computeHorizontalScrollbarHeight(document) } });
+      Elm.Main.init({ node: document.getElementById('elm') });
     </script>
   </body>
 </html>

--- a/src/Internal/TabBar/Implementation.elm
+++ b/src/Internal/TabBar/Implementation.elm
@@ -3,7 +3,6 @@ module Internal.TabBar.Implementation exposing
     , Tab
     , activeTab
     , fadingIconIndicator
-    , horizontalScrollbarHeight
     , icon
     , indicatorIcon
     , react
@@ -189,8 +188,6 @@ type alias Config =
     , activeTab : Int
     , icon : Maybe String
     , smallIndicator : Bool
-    -- This value must be set as config value for every tab bar that could scroll.
-    , horizontalScrollbarHeight : Int
     , indicatorIcon : Maybe String
     , fadingIconIndicator : Bool
     }
@@ -202,9 +199,6 @@ defaultConfig =
     , activeTab = 0
     , icon = Nothing
     , smallIndicator = False
-    -- A value of 10 worked in the past for at least FireFox. On my machine I now need 8.
-    -- Chrome needs 0.
-    , horizontalScrollbarHeight = 0
     , indicatorIcon = Nothing
     , fadingIconIndicator = False
     }
@@ -246,11 +240,6 @@ stacked =
 smallIndicator : Property m
 smallIndicator =
     Options.option (\config -> { config | smallIndicator = True })
-
-
-horizontalScrollbarHeight : Int -> Property m
-horizontalScrollbarHeight height =
-    Options.option (\config -> { config | horizontalScrollbarHeight = height })
 
 
 indicatorIcon : String -> Property m
@@ -340,7 +329,7 @@ scroller domId lift model options nodes =
             [ Options.id (domId ++ "__scroll-area")
             , cs "mdc-tab-scroller__scroll-area"
             , cs "mdc-tab-scroller__scroll-area--scroll"
-            , css "margin-bottom" (String.fromInt -config.horizontalScrollbarHeight ++ "px")
+            , css "margin-bottom" "calc(-1 * var(--elm-mdc-horizontal-scrollbar-height))"
             ]
             [ Options.apply summary
                 div

--- a/src/Material/TabBar.elm
+++ b/src/Material/TabBar.elm
@@ -7,7 +7,6 @@ module Material.TabBar exposing
     , icon
     , stacked
     , smallIndicator
-    , horizontalScrollbarHeight
     , indicatorIcon
     , fadingIconIndicator
     )
@@ -60,7 +59,6 @@ update the active tab in your model.
 @docs icon
 @docs stacked
 @docs smallIndicator
-@docs horizontalScrollbarHeight
 @docs indicatorIcon
 @docs fadingIconIndicator
 
@@ -134,31 +132,6 @@ stacked =
 smallIndicator : Property m
 smallIndicator =
     TabBar.smallIndicator
-
-
-{-| The height of the horizontal scrollbar. Needs to be set correctly
-if tab bar needs scrolling.
-
-Elm cannot calculate this value (it would require a call to
-JavaScript), so it needs to be passed to the application via a flag.
-
-The value can be calculated by calling the javascript function
-`ElmMdc.computeHorizontalScrollbarHeight()`.
-
-Example of passing the value as a flag:
-
-```javascript
-Elm.Main.init(
-  { node: document.getElementById('elm')
-  , flags: { horizontalScrollbarHeight: ElmMdc.computeHorizontalScrollbarHeight(document) }
-  })
-```
-
-Your application will then need to store this in its model and pass it to every Tab Bar.
--}
-horizontalScrollbarHeight : Int -> Property m
-horizontalScrollbarHeight =
-    TabBar.horizontalScrollbarHeight
 
 
 {-| Indicates the icon to use for the sliding indicator icon effect.

--- a/src/elm-mdc.js
+++ b/src/elm-mdc.js
@@ -243,23 +243,12 @@ import CustomEvent from 'custom-event';
 
 
 /**
- * Stores result from computeHorizontalScrollbarHeight to avoid redundant processing.
- * @private {number|undefined}
- */
-export let horizontalScrollbarHeight_
-
-/**
  * Computes the height of browser-rendered horizontal scrollbars using a self-created test element.
  * May return 0 (e.g. on OS X browsers under default configuration).
  * @param {!Document} documentObj
- * @param {boolean=} shouldCacheResult
  * @return {number}
  */
-export function computeHorizontalScrollbarHeight(documentObj, shouldCacheResult = true) {
-  if (shouldCacheResult && typeof horizontalScrollbarHeight_ !== "undefined") {
-    return horizontalScrollbarHeight_;
-  }
-
+export function computeHorizontalScrollbarHeight(documentObj) {
   const el = documentObj.createElement("div");
   el.classList.add("mdc-tab-scroller__test");
   documentObj.body.appendChild(el);
@@ -267,8 +256,23 @@ export function computeHorizontalScrollbarHeight(documentObj, shouldCacheResult 
   const horizontalScrollbarHeight = el.offsetHeight - el.clientHeight;
   documentObj.body.removeChild(el);
 
-  if (shouldCacheResult) {
-    horizontalScrollbarHeight_ = horizontalScrollbarHeight;
-  }
   return horizontalScrollbarHeight;
 }
+
+
+/**
+ * Sets height of horizontal scrollbar as CSS variable.
+ */
+function setHorizontalScrollbarHeight(documentObj) {
+  const height = computeHorizontalScrollbarHeight(documentObj);
+  const style = documentObj.createElement("style");
+  style.innerHTML = ":root { --elm-mdc-horizontal-scrollbar-height: " + height + "px; }";
+  documentObj.head.appendChild(style);
+}
+
+
+/**
+ * Make height of horizontal scrollbar available to elm-mdc.
+ * Tip: https://discourse.elm-lang.org/t/calculating-the-height-of-the-horizontal-scrollbar-really-need-to-call-javascript/3493/9?u=berend
+ */
+setHorizontalScrollbarHeight(document);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,6 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, './'),
     filename: 'elm-mdc.js',
-    library: 'ElmMdc'
   },
   module: {
     rules: [


### PR DESCRIPTION
This greatly simplifies the API, no need for flags, no need to pass the value as config to every tab bar.