### PR TITLE
Change snackbar timeout from 2750ms to 5000ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## IN PROGRESS
+
+Changes:
+* Snackbar timeout default is now 5 seconds to be compatible with
+  the JavaScript version.
+
+
 ## Upgrade to 2.2.0
 
 New features:

--- a/src/Internal/Snackbar/Implementation.elm
+++ b/src/Internal/Snackbar/Implementation.elm
@@ -25,7 +25,7 @@ toast : Maybe m -> String -> Contents m
 toast onDismiss message =
     { message = message
     , action = Nothing
-    , timeout = 2750
+    , timeout = 5000
     , fade = 250
     , stacked = False
     , dismissOnAction = True
@@ -37,7 +37,7 @@ snack : Maybe m -> String -> String -> Contents m
 snack onDismiss message label =
     { message = message
     , action = Just label
-    , timeout = 2750
+    , timeout = 5000
     , fade = 250
     , stacked = True
     , dismissOnAction = True

--- a/src/Material/Snackbar.elm
+++ b/src/Material/Snackbar.elm
@@ -85,7 +85,11 @@ view =
     Snackbar.view
 
 
-{-| Snackbar Contents.
+{-| Snackbar contents.
+
+Note that [according to the
+specification](https://material.io/design/components/snackbars.html)
+the minimum timeout is 4000ms.
 -}
 type alias Contents m =
     { message : String
@@ -98,7 +102,9 @@ type alias Contents m =
     }
 
 
-{-| Generate toast with given message. Timeout is 2750ms, fade 250ms.
+{-| Generate toast with given message. Timeout is 5000ms, fade 250ms.
+
+The optional command is sent when the action button is triggered.
 -}
 toast : Maybe m -> String -> Contents m
 toast =
@@ -106,7 +112,9 @@ toast =
 
 
 {-| Generate snack with given message and label.
-Timeout is 2750ms, fade 250ms.
+Timeout is 5000ms, fade 250ms.
+
+The optional command is sent when the action button is triggered.
 -}
 snack : Maybe m -> String -> String -> Contents m
 snack =


### PR DESCRIPTION
Just as Material Components for the Web has it.