### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,21 @@
-elm-stuff
 .*.sw?
 *~
-elm.js
-elm-mdc.js.map
-index.html
-docs.json
-documentation.json
+.DS_Store
 .vscode/
 
+elm-stuff/
 test.html
-examples/counter-many.html
-examples/counter1-no-parts.html
-examples/counter1.html
 
-.DS_Store
+/elm-mdc.js
+/elm-mdc.js.map
+/material-components-web.css
+/docs.json
 
-build
-node_modules
-.sass-cache
+/examples/counter-many.html
+/examples/counter1-no-parts.html
+/examples/counter1.html
 
-elm-mdc.js
-material-components-web.css
+/.sass-cache/
+/build/
+/node_modules/
+/v8-compile-cache-0/


### PR DESCRIPTION
The `.gitignore` file has quite a few rules that will match in any directory, even though a file matching that rule has been committed. For example, `src/elm-mdc.js` is matched by `elm-mdc.js` when it seems as though only the `/elm-mdc.js` produced during a build is intended to be excluded.

I've tightened up the ignore rules by based on the files produced when I build the project locally. There's a few instances where I've had to make an educated guess (e.g. I never found `test.html` but assumed someone may have created files matching that on their machine for testing, so I've left that particular rule in there).