### PR TITLE
Lists: improve handling of selected state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Latest changes
+
+Changes:
+* Lists: In addition to using selectedIndex you can use the selected
+  state on a list item. Depending on the use case on or the other
+  might be easier.
+
+Fixes:
+* Lists: the activated item will receive the keyboard focus by default instead of the first.
+
+
 ## Upgrade to 3.1.1
 
 New features

--- a/src/Material/List.elm
+++ b/src/Material/List.elm
@@ -127,6 +127,13 @@ an awkward interface. They need a ListItem type. Usually this is
 transparent, but you'll notice when you try to use ordinary html
 inside a list. In that case prefix your html with `asListItem`.
 
+List items automatically get keyboard focus. Here's the algorithm
+elm-mdc follows:
+
+* If you have set `selectedIndex`, that item will receive the focus.
+* The first list item which has the `selected` or `activated` state will receive the focus.
+* Else the first list item will receive the focus.
+
 @docs ListItem
 @docs li
 @docs a


### PR DESCRIPTION
You can now either use selectedIndex on the list, or the selected state on a list item to indicate the item that should receive the focus.