### PR TITLE
Introduce Button.label property

### DIFF
--- a/demo/Demo/Buttons.elm
+++ b/demo/Demo/Buttons.elm
@@ -81,42 +81,42 @@ view lift page model =
     page.body
         "Button"
         "Buttons communicate an action a user can take. They are typically placed throughout your UI, in places like dialogs, forms, cards, and toolbars."
-        ( Hero.view []
+        (Hero.view []
             [ Button.view (lift << Mdc)
                 "buttons-hero-button-text"
                 model.mdc
-                [ Button.ripple
+                [ Button.label "Text"
+                , Button.ripple
                 , css "margin" "16px 32px"
                 ]
-                [ text "Text"
-                ]
+                []
             , Button.view (lift << Mdc)
                 "buttons-hero-button-raised"
                 model.mdc
-                [ Button.ripple
+                [ Button.label "Raised"
+                , Button.ripple
                 , Button.raised
                 , css "margin" "16px 32px"
                 ]
-                [ text "Raised"
-                ]
+                []
             , Button.view (lift << Mdc)
                 "buttons-hero-button-unelevated"
                 model.mdc
-                [ Button.ripple
+                [ Button.label "Unelevated"
+                , Button.ripple
                 , Button.unelevated
                 , css "margin" "16px 32px"
                 ]
-                [ text "Unelevated"
-                ]
+                []
             , Button.view (lift << Mdc)
                 "buttons-hero-button-outlined"
                 model.mdc
-                [ Button.ripple
+                [ Button.label "Outlined"
+                , Button.ripple
                 , Button.outlined
                 , css "margin" "16px 32px"
                 ]
-                [ text "Outlined"
-                ]
+                []
             ]
         )
         [ ResourceLink.links (lift << Mdc) model.mdc "buttons" "buttons" "mdc-button"
@@ -153,27 +153,30 @@ example idx lift model { title, additionalOptions } =
                 (idx ++ "-default-button")
                 model.mdc
                 (css "margin" "8px 16px"
+                    :: Button.label "Default"
                     :: Button.ripple
                     :: additionalOptions
                 )
-                [ text "Default" ]
+                []
             , Button.view (lift << Mdc)
                 (idx ++ "-dense-button")
                 model.mdc
                 (css "margin" "8px 16px"
+                    :: Button.label "Dense"
                     :: Button.ripple
                     :: Button.dense
                     :: additionalOptions
                 )
-                [ text "Dense" ]
+                []
             , Button.view (lift << Mdc)
                 (idx ++ "-icon-button")
                 model.mdc
                 (css "margin" "8px 16px"
+                    :: Button.label "Icon"
                     :: Button.ripple
                     :: Button.icon "favorite"
                     :: additionalOptions
                 )
-                [ text "Icon" ]
+                []
             ]
         ]

--- a/demo/Demo/Cards.elm
+++ b/demo/Demo/Cards.elm
@@ -90,18 +90,18 @@ cardActions lift index model =
                 (index ++ "-action-button-read")
                 model.mdc
                 [ Card.actionButton
+                , Button.label "Read"
                 , Button.ripple
                 ]
-                [ text "Read"
-                ]
+                []
             , Button.view (lift << Mdc)
                 (index ++ "-action-button-bookmark")
                 model.mdc
                 [ Card.actionButton
+                , Button.label "Bookmark"
                 , Button.ripple
                 ]
-                [ text "Bookmark"
-                ]
+                []
             ]
         , Card.actionIcons []
             [ IconButton.view (lift << Mdc)
@@ -233,7 +233,7 @@ view lift page model =
     page.body
         "Card"
         "Cards contain content and actions about a single subject."
-        ( Hero.view []
+        (Hero.view []
             [ heroCard lift "card-hero-card" model
             ]
         )

--- a/demo/Demo/Dialog.elm
+++ b/demo/Demo/Dialog.elm
@@ -68,19 +68,19 @@ heroDialog lift index model =
             [ Button.view (lift << Mdc)
                 (index ++ "-button-cancel")
                 model.mdc
-                [ Button.ripple
+                [ Button.label "Decline"
+                , Button.ripple
                 , Dialog.cancel
                 ]
-                [ text "Decline"
-                ]
+                []
             , Button.view (lift << Mdc)
                 (index ++ "button-accept")
                 model.mdc
-                [ Button.ripple
+                [ Button.label "Accept"
+                , Button.ripple
                 , Dialog.accept
                 ]
-                [ text "Accept"
-                ]
+                []
             ]
         ]
 
@@ -100,21 +100,21 @@ alertDialog lift index model =
             [ Button.view (lift << Mdc)
                 (index ++ "-button-cancel")
                 model.mdc
-                [ Button.ripple
+                [ Button.label "Cancel"
+                , Button.ripple
                 , Dialog.cancel
                 , Options.onClick (lift Close)
                 ]
-                [ text "Cancel"
-                ]
+                []
             , Button.view (lift << Mdc)
                 (index ++ "-button-accept")
                 model.mdc
-                [ Button.ripple
+                [ Button.label "Discard"
+                , Button.ripple
                 , Dialog.accept
                 , Options.onClick (lift Close)
                 ]
-                [ text "Discard"
-                ]
+                []
             ]
         ]
 
@@ -229,21 +229,21 @@ confirmationDialog lift index model =
             [ Button.view (lift << Mdc)
                 (index ++ "-button-cancel")
                 model.mdc
-                [ Button.ripple
+                [ Button.label "Cancel"
+                , Button.ripple
                 , Dialog.cancel
                 , Options.onClick (lift Close)
                 ]
-                [ text "Cancel"
-                ]
+                []
             , Button.view (lift << Mdc)
                 (index ++ "-button-accept")
                 model.mdc
-                [ Button.ripple
+                [ Button.label "OK"
+                , Button.ripple
                 , Dialog.accept
                 , Options.onClick (lift Close)
                 ]
-                [ text "OK"
-                ]
+                []
             ]
         ]
 
@@ -355,21 +355,21 @@ scrollableDialog lift index model =
             [ Button.view (lift << Mdc)
                 (index ++ "-button-cancel")
                 model.mdc
-                [ Button.ripple
+                [ Button.label "Decline"
+                , Button.ripple
                 , Dialog.cancel
                 , Options.onClick (lift Close)
                 ]
-                [ text "Decline"
-                ]
+                []
             , Button.view (lift << Mdc)
                 (index ++ "-button-accept")
                 model.mdc
-                [ Button.ripple
+                [ Button.label "Continue"
+                , Button.ripple
                 , Dialog.accept
                 , Options.onClick (lift Close)
                 ]
-                [ text "Continue"
-                ]
+                []
             ]
         ]
 
@@ -379,7 +379,7 @@ view lift page model =
     page.body
         "Dialog"
         "Dialogs inform users about a specific task and may contain critical information, require decisions, or involve multiple tasks."
-        ( Hero.view []
+        (Hero.view []
             [ heroDialog lift "dialog-hero-dialog" model
             ]
         )
@@ -388,38 +388,38 @@ view lift page model =
             [ Button.view (lift << Mdc)
                 "dialog-show-alert"
                 model.mdc
-                [ Button.ripple
+                [ Button.label "Alert"
+                , Button.ripple
                 , Options.onClick (lift (Show "dialog-alert-dialog"))
                 ]
-                [ text "Alert"
-                ]
+                []
             , text " "
             , Button.view (lift << Mdc)
                 "dialog-show-simple"
                 model.mdc
-                [ Button.ripple
+                [ Button.label "Simple"
+                , Button.ripple
                 , Options.onClick (lift (Show "dialog-simple-dialog"))
                 ]
-                [ text "Simple"
-                ]
+                []
             , text " "
             , Button.view (lift << Mdc)
                 "dialog-show-confirmation-dialog"
                 model.mdc
-                [ Button.ripple
+                [ Button.label "Confirmation"
+                , Button.ripple
                 , Options.onClick (lift (Show "dialog-confirmation-dialog"))
                 ]
-                [ text "Confirmation"
-                ]
+                []
             , text " "
             , Button.view (lift << Mdc)
                 "dialog-show-scrollable-dialog"
                 model.mdc
-                [ Button.ripple
+                [ Button.label "Scrollable"
+                , Button.ripple
                 , Options.onClick (lift (Show "dialog-scrollable-dialog"))
                 ]
-                [ text "Scrollable"
-                ]
+                []
             , alertDialog lift "dialog-alert-dialog" model
             , simpleDialog lift "dialog-simple-dialog" model
             , confirmationDialog lift "dialog-confirmation-dialog" model

--- a/demo/Demo/Menus.elm
+++ b/demo/Demo/Menus.elm
@@ -59,15 +59,17 @@ view lift page model =
     page.body
         "Menu"
         "Menus display a list of choices on a transient sheet of material."
-        ( Hero.view [] [ heroMenu lift model ] )
+        (Hero.view [] [ heroMenu lift model ])
         [ ResourceLink.links (lift << Mdc) model.mdc "menus" "menus" "mdc-menu"
         , Page.demos
             [ styled Html.h3 [ Typography.subtitle1 ] [ text "Anchored menu" ]
             , Button.view (lift << Mdc)
                 "menus-button"
                 model.mdc
-                [ Menu.attach (lift << Mdc) "menus-menu" ]
-                [ text "Open menu" ]
+                [ Button.label "Open menu"
+                , Menu.attach (lift << Mdc) "menus-menu"
+                ]
+                []
             , styled div
                 [ Menu.surfaceAnchor ]
                 [ Menu.view (lift << Mdc)

--- a/demo/Demo/PermanentDrawer.elm
+++ b/demo/Demo/PermanentDrawer.elm
@@ -82,7 +82,8 @@ drawerItems lift index mdc url select selected =
             mdc
             [ Lists.singleSelection
             , Lists.useActivated
-            , Lists.onSelectListItem select ]
+            , Lists.onSelectListItem select
+            ]
             [ Lists.a
                 [ href
                 , Lists.activated |> when (selected == 0)
@@ -181,10 +182,10 @@ mainContent model mdc rtl_index cmd =
         , Button.view mdc
             rtl_index
             model.mdc
-            [ Options.on "click" (Json.succeed cmd)
+            [ Button.label "Toggle RTL"
+            , Options.on "click" (Json.succeed cmd)
             ]
-            [ text "Toggle RTL"
-            ]
+            []
         ]
 
 

--- a/demo/Demo/Snackbar.elm
+++ b/demo/Demo/Snackbar.elm
@@ -47,7 +47,8 @@ update lift msg model =
 
         Show idx message label ->
             let
-                stacked = idx == "snackbar-stacked"
+                stacked =
+                    idx == "snackbar-stacked"
 
                 contents =
                     let
@@ -57,10 +58,11 @@ update lift msg model =
                                 message
                                 label
                     in
-                        { snack
-                            | dismissOnAction = True
-                            , stacked = stacked
-                        }
+                    { snack
+                        | dismissOnAction = True
+                        , stacked = stacked
+                    }
+
                 ( mdc, effects ) =
                     Snackbar.add (lift << Mdc) idx contents model.mdc
             in
@@ -70,23 +72,25 @@ update lift msg model =
             ( model, Cmd.none )
 
 
-
 snackbarButton lift index mdc buttonLabel message action =
     Button.view (lift << Mdc)
-        ( "button-" ++index )
+        ("button-" ++ index)
         mdc
-        [ Button.raised
+        [ Button.label buttonLabel
+        , Button.raised
         , Options.on "click" (Json.succeed (lift (Show ("snackbar-" ++ index) message action)))
         , css "margin" "8px 16px"
         ]
-        [ text buttonLabel
-        ]
+        []
+
 
 baselineButton lift mdc =
     snackbarButton lift "baseline" mdc "Baseline" "Can't send photo. Retry in 5 seconds." "Retry"
 
+
 leadingButton lift mdc =
     snackbarButton lift "leading" mdc "Leading" "Your photo has been archived." "Undo"
+
 
 stackedButton lift mdc =
     snackbarButton lift "stacked" mdc "Stacked" "This item already has the label \"travel\". You can add a new label." "Add a new label"
@@ -132,7 +136,7 @@ view lift page model =
     page.body
         "Snackbar"
         "Snackbars provide brief messages about app processes at the bottom of the screen."
-        ( Hero.view []
+        (Hero.view []
             [ styled Html.div
                 [ css "position" "relative"
                 , css "left" "0"

--- a/demo/Demo/Theme.elm
+++ b/demo/Demo/Theme.elm
@@ -38,23 +38,23 @@ view lift page model =
     page.body
         "Theme"
         "Color in Material Design is inspired by bold hues juxtaposed with muted environments, deep shadows, and bright highlights."
-        ( Hero.view []
+        (Hero.view []
             [ Button.view (lift << Mdc)
                 "theme-button-primary"
                 model.mdc
-                [ Button.raised
+                [ Button.label "Primary"
+                , Button.raised
                 , css "margin" "24px"
                 ]
-                [ text "Primary"
-                ]
+                []
             , Button.view (lift << Mdc)
                 "theme-button-secondary"
                 model.mdc
-                [ Button.raised
+                [ Button.label "Secondary"
+                , Button.raised
                 , css "margin" "24px"
                 ]
-                [ text "Secondary"
-                ]
+                []
             ]
         )
         [ ResourceLink.links (lift << Mdc) model.mdc "color/applying-color-to-ui" "theme" "mdc-theme"

--- a/demo/Demo/TopAppBar.elm
+++ b/demo/Demo/TopAppBar.elm
@@ -101,7 +101,7 @@ view lift page topAppBarPage model =
             page.body
                 "Top App Bar"
                 "Top App Bars are a container for items such as application title, navigation icon, and action items."
-                ( Hero.view []
+                (Hero.view []
                     [ styled Html.div
                         [ css "width" "480px"
                         , css "height" "72px"
@@ -347,12 +347,12 @@ body options lift index model =
             [ [ Button.view (lift << Mdc)
                     (index ++ "-toggle-rtl")
                     model.mdc
-                    [ Button.outlined
+                    [ Button.label "Toggle RTL"
+                    , Button.outlined
                     , Button.dense
                     , Options.onClick (lift (ExampleMsg (index ++ "-toggle-rtl") ToggleRtl))
                     ]
-                    [ text "Toggle RTL"
-                    ]
+                    []
               ]
             , List.repeat 18 <|
                 Html.p []

--- a/src/Internal/Button/Implementation.elm
+++ b/src/Internal/Button/Implementation.elm
@@ -3,6 +3,7 @@ module Internal.Button.Implementation exposing
     , dense
     , disabled
     , icon
+    , label
     , link
     , onClick
     , outlined
@@ -52,6 +53,7 @@ update lift msg model =
 
 type alias Config m =
     { ripple : Bool
+    , label : Maybe String
     , link : Maybe String
     , disabled : Bool
     , icon : Maybe String
@@ -63,6 +65,7 @@ type alias Config m =
 defaultConfig : Config m
 defaultConfig =
     { ripple = False
+    , label = Nothing
     , link = Nothing
     , disabled = False
     , icon = Nothing
@@ -73,6 +76,11 @@ defaultConfig =
 
 type alias Property m =
     Options.Property (Config m) m
+
+
+label : String -> Property m
+label str =
+    Options.option (\config -> { config | label = Just str })
 
 
 icon : String -> Property m
@@ -170,6 +178,9 @@ button domId lift model options nodes =
 
               else
                 []
+            , config.label
+                |> Maybe.map (\label_ -> [ Html.span [ Html.class "mdc-button__label" ] [ Html.text label_ ] ])
+                |> Maybe.withDefault []
             , nodes
             , if config.trailingIcon then
                 config.icon

--- a/src/Material/Button.elm
+++ b/src/Material/Button.elm
@@ -11,6 +11,7 @@ module Material.Button exposing
     , disabled
     , link
     , onClick
+    , label
     )
 
 {-| The Button component is a spec-aligned button component adhering to the
@@ -32,11 +33,11 @@ Material Design button requirements.
 
 
     Button.view Mdc "my-button" model.mdc
-        [ Button.ripple
+        [ Button.label "Button"
+        , Button.ripple
         , Options.onClick Click
         ]
-        [ text "Button"
-        ]
+        []
 
 
 # Usage
@@ -79,6 +80,16 @@ view :
     -> Html m
 view =
     Button.view
+
+
+{-| Give the button a label.
+
+Explicitly setting the label will ensure that any trailing icon will be properly styled.
+
+-}
+label : String -> Property m
+label =
+    Button.label
 
 
 {-| Give the button an icon.

--- a/src/Material/Button.elm
+++ b/src/Material/Button.elm
@@ -1,6 +1,7 @@
 module Material.Button exposing
     ( Property
     , view
+    , label
     , ripple
     , raised
     , unelevated
@@ -11,7 +12,6 @@ module Material.Button exposing
     , disabled
     , link
     , onClick
-    , label
     )
 
 {-| The Button component is a spec-aligned button component adhering to the
@@ -44,6 +44,7 @@ Material Design button requirements.
 
 @docs Property
 @docs view
+@docs label
 @docs ripple
 @docs raised
 @docs unelevated


### PR DESCRIPTION
This pull request introduces a Button.label property. The string value provided to the label is rendered like this:

```<span class="mdc-button__label">My label</span>```

That way, you get the icons properly styled around the label, even if the label is trailing.

I've made it backwards-compatible, so if you just add text to the content list, you still get a nice-looking button.