### PR TITLE
fix: use focus events that bubble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Latest changes
 
+Breaking changes:
+- Possibly breaking change: Options.onFocus and Options.onBlur now
+  bubble focus and blur by using focusin and focusout
+  respectively. This leads to a more natural API.
+
 
 ## Upgrade to 7.0.0
 

--- a/src/Internal/Options.elm
+++ b/src/Internal/Options.elm
@@ -468,12 +468,12 @@ onCheck toMsg =
 
 onBlur : msg -> Property c msg
 onBlur msg =
-    on "blur" (Decode.succeed msg)
+    on "focusout" (Decode.succeed msg)
 
 
 onFocus : msg -> Property c msg
 onFocus msg =
-    on "focus" (Decode.succeed msg)
+    on "focusin" (Decode.succeed msg)
 
 
 onInput : (String -> m) -> Property c m

--- a/src/Material/Options.elm
+++ b/src/Material/Options.elm
@@ -267,24 +267,16 @@ onCheck =
 
 
 {-| See `onFocus` for additional information.
+
+The underlying implementation actually uses "focusout" instead of the "blur" event.
 -}
 onBlur : msg -> Property c msg
 onBlur =
     Internal.Options.onBlur
 
 
-{-| Since the `"focus"` (and `"blur"`) event does not bubble, be sure to use
-this on `nativeControl` if the component exposes that.
-
-    import Material.TextField as TextField
-
-    TextField.view Mdc "my-text-field" model.mdc
-        [ TextField.nativeControl
-            [ Options.onFocus Focus
-            ]
-        ]
-        []
-
+{-| Since the `"focus"` (and `"blur"`) event does not bubble, the
+underlying implementation actually uses the "focusin" event.
 -}
 onFocus : msg -> Property c msg
 onFocus =


### PR DESCRIPTION
focus and blur need to be applied to the nativeControl, leading to
"unexpected" behaviour. Experiment to see if this works better.