### PR TITLE
refactor: remove Material.init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Fixes:
 - elm-mdc.js: import of focusTrap incorrect since upgrade to v6.
 - docs did not compile.
 
+Breaking changes:
+- Material.init removed, as it didn't do anything.
+
 
 # Upgrade to 10.0.0
 

--- a/demo/Demo.elm
+++ b/demo/Demo.elm
@@ -655,7 +655,7 @@ init flags url key =
             defaultModel key
     in
     ( { initialModel | url = Demo.Url.fromUrl url }
-    , Cmd.batch [ Material.init Mdc, Task.perform GotViewportWidth Browser.Dom.getViewport ]
+    , Task.perform GotViewportWidth Browser.Dom.getViewport
     )
 
 

--- a/src/Material.elm
+++ b/src/Material.elm
@@ -2,7 +2,6 @@ module Material exposing
     ( Model
     , defaultModel
     , Msg
-    , init
     , subscriptions
     , update
     , Index
@@ -97,7 +96,7 @@ Set the `mdc-typography` class on the body or container of your application:
 
     init : ( Model, Cmd Msg )
     init =
-        ( defaultModel, Material.init Mdc )
+        ( defaultModel, Cmd.none )
 
 
     subscriptions : Model -> Sub Msg
@@ -139,7 +138,6 @@ Set the `mdc-typography` class on the body or container of your application:
 @docs Model
 @docs defaultModel
 @docs Msg
-@docs init
 @docs subscriptions
 @docs update
 @docs Index
@@ -377,27 +375,6 @@ update_ lift msg store =
 subscriptions : (Msg m -> m) -> { model | mdc : Model m } -> Sub m
 subscriptions lift model =
     Sub.batch [ Menu.subs lift model.mdc, Select.subs lift model.mdc ]
-
-
-{-| Material init.
-
-    init =
-        let
-            defaultModel =
-                …
-
-            effects =
-                Cmd.batch
-                [ Material.init Mdc
-                , …
-                ]
-        in
-        ( defaultModel, effects )
-
--}
-init : (Msg m -> m) -> Cmd m
-init _ =
-    Cmd.none
 
 
 {-| A top-level wrapper for quick prototyping. This wraps your HTML content and


### PR DESCRIPTION
Possibly breaking change, but very easy to fix, just remove
`Material.init` from your code.

Fixes #307.